### PR TITLE
유저 데이터 음식 구현 완료

### DIFF
--- a/dieat/src/main/java/com/samsung/dieat/user_data_food/query/controller/UserDataFoodQueryController.java
+++ b/dieat/src/main/java/com/samsung/dieat/user_data_food/query/controller/UserDataFoodQueryController.java
@@ -2,6 +2,8 @@ package com.samsung.dieat.user_data_food.query.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,8 +19,33 @@ public class UserDataFoodQueryController {
     private final UserDataFoodQueryService userDataFoodQueryService;
 
     @GetMapping("/{udfCode}")
-    public UserDataFoodDTO getUserDataFood(@PathVariable int udfCode) {
-        System.out.println(udfCode);
-        return userDataFoodQueryService.getUserDataFoodByUdfCode(udfCode);
+    public ResponseEntity<UserDataFoodDTO> getUserDataFoodByUdfCode(@PathVariable int udfCode) {
+        UserDataFoodDTO result = userDataFoodQueryService.getUserDataFoodByUdfCode(udfCode);
+        return ResponseEntity.status(HttpStatus.OK).body(result);   // 200 + 데이터 반환
+        /* 설명: 결과값이 없어도 OK를 보내는 이유
+        *   결과값이 없는 것이지 잘못된 요청이 들어온 것이 아니기 때문
+        *   하지만 어떻게 처리할 지 추가 논의 필요
+        *   1. 프론트에서 결과값이 없는 경우 처리
+        *   2. Exception을 만들어서 처리*/
+
+        /* 설명: Exception을 만들어서 처리하는 방법*/
+        /*@GetMapping("/{udfCode}")
+        public ResponseEntity<UserDataFoodDTO> getUserDataFood(@PathVariable int udfCode) {
+            UserDataFoodDTO dto = userDataFoodQueryService.getUserDataFoodByUdfCode(udfCode);
+            if (dto == null) {
+                throw new ResourceNotFoundException("UserDataFood not found: " + udfCode);
+            }
+            return ResponseEntity.ok(dto);
+        }*/
+        /* 설명: 컨트롤러를 위 코드로 대체
+        *   이후 아래 GlobalExceptionHandler 처리*/
+        /*@RestControllerAdvice
+        public class GlobalExceptionHandler {
+
+            @ExceptionHandler(ResourceNotFoundException.class)
+            public ResponseEntity<String> handleResourceNotFound(ResourceNotFoundException ex) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+            }
+        }*/
     }
 }

--- a/dieat/src/main/java/com/samsung/dieat/user_data_food/query/controller/UserDataFoodQueryController.java
+++ b/dieat/src/main/java/com/samsung/dieat/user_data_food/query/controller/UserDataFoodQueryController.java
@@ -1,7 +1,9 @@
 package com.samsung.dieat.user_data_food.query.controller;
 
+import com.samsung.dieat.user_data_food.query.dto.ResponseUdfName;
+import com.samsung.dieat.user_data_food.query.dto.ResponseUserDataFood;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,7 +20,7 @@ public class UserDataFoodQueryController {
 
     private final UserDataFoodQueryService userDataFoodQueryService;
 
-    @GetMapping("/{udfCode}")
+    @GetMapping("/code/{udfCode}")
     public ResponseEntity<UserDataFoodDTO> getUserDataFoodByUdfCode(@PathVariable int udfCode) {
         UserDataFoodDTO result = userDataFoodQueryService.getUserDataFoodByUdfCode(udfCode);
         return ResponseEntity.status(HttpStatus.OK).body(result);   // 200 + 데이터 반환
@@ -48,4 +50,20 @@ public class UserDataFoodQueryController {
             }
         }*/
     }
+
+    @GetMapping("/like/{likeName}")
+    public ResponseEntity<List<ResponseUdfName>> getUserDataFoodByLikeName(@PathVariable String likeName) {
+        List<ResponseUdfName> result = userDataFoodQueryService.getUserDataFoodByLikeName(likeName);
+        if (result.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.OK).build();    // 검색 결과가 없어도 OK
+        }
+        return ResponseEntity.status(HttpStatus.OK).body(result);
+    }
+
+    @GetMapping("/name/{udfName}")
+    public ResponseEntity<List<ResponseUserDataFood>> getUserDataFoodWithNickname(@PathVariable String udfName) {
+        List<ResponseUserDataFood> result = userDataFoodQueryService.getUserDataFoodWithNickname(udfName);
+        return ResponseEntity.ok(result);
+    }
+
 }

--- a/dieat/src/main/java/com/samsung/dieat/user_data_food/query/dao/UserDataFoodMapper.java
+++ b/dieat/src/main/java/com/samsung/dieat/user_data_food/query/dao/UserDataFoodMapper.java
@@ -1,9 +1,16 @@
 package com.samsung.dieat.user_data_food.query.dao;
 
+import com.samsung.dieat.user_data_food.query.dto.ResponseUdfName;
+import com.samsung.dieat.user_data_food.query.dto.ResponseUserDataFood;
+import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import com.samsung.dieat.user_data_food.query.dto.UserDataFoodDTO;
 
 @Mapper
 public interface UserDataFoodMapper {
     UserDataFoodDTO findByUdfCode(int udfCode);
+
+    List<ResponseUdfName> findByLikeName(String likeName);
+
+    List<ResponseUserDataFood> findByUdfNameWithNickname(String udfName);
 }

--- a/dieat/src/main/java/com/samsung/dieat/user_data_food/query/dao/UserDataFoodMapper.java
+++ b/dieat/src/main/java/com/samsung/dieat/user_data_food/query/dao/UserDataFoodMapper.java
@@ -5,12 +5,13 @@ import com.samsung.dieat.user_data_food.query.dto.ResponseUserDataFood;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import com.samsung.dieat.user_data_food.query.dto.UserDataFoodDTO;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface UserDataFoodMapper {
     UserDataFoodDTO findByUdfCode(int udfCode);
 
-    List<ResponseUdfName> findByLikeName(String likeName);
+    List<ResponseUdfName> findByMultipleKeywords(@Param("keywords") List<String> keywords);
 
     List<ResponseUserDataFood> findByUdfNameWithNickname(String udfName);
 }

--- a/dieat/src/main/java/com/samsung/dieat/user_data_food/query/dto/ResponseUdfName.java
+++ b/dieat/src/main/java/com/samsung/dieat/user_data_food/query/dto/ResponseUdfName.java
@@ -1,0 +1,8 @@
+package com.samsung.dieat.user_data_food.query.dto;
+
+import lombok.Data;
+
+@Data
+public class ResponseUdfName {
+    private String udfName;
+}

--- a/dieat/src/main/java/com/samsung/dieat/user_data_food/query/dto/ResponseUserDataFood.java
+++ b/dieat/src/main/java/com/samsung/dieat/user_data_food/query/dto/ResponseUserDataFood.java
@@ -1,0 +1,21 @@
+package com.samsung.dieat.user_data_food.query.dto;
+
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+public class ResponseUserDataFood {
+    private String udfName;
+    private int udfSvSize;
+    private String udfUom;
+    private String udfSvUnit;
+    private float udfCalories;
+    private Float udfCarbs;
+    private Float udfProtein;
+    private Float udfFat;
+    private Float udfSugar;
+    private int udfAccCnt;
+    private int udfInaccCnt;
+    private LocalDateTime udfCreatedDt;
+    private String userNickname;  // user_nickname 추가
+}

--- a/dieat/src/main/java/com/samsung/dieat/user_data_food/query/service/UserDataFoodQueryService.java
+++ b/dieat/src/main/java/com/samsung/dieat/user_data_food/query/service/UserDataFoodQueryService.java
@@ -2,6 +2,7 @@ package com.samsung.dieat.user_data_food.query.service;
 
 import com.samsung.dieat.user_data_food.query.dto.ResponseUdfName;
 import com.samsung.dieat.user_data_food.query.dto.ResponseUserDataFood;
+import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,9 +19,11 @@ public class UserDataFoodQueryService {
         return userDataFoodMapper.findByUdfCode(udfCode);
     }
 
-    public List<ResponseUdfName> getUserDataFoodByLikeName(String likeName) {
-        return userDataFoodMapper.findByLikeName(likeName);
+    public List<ResponseUdfName> getUserDataFoodByLikeName(String keyword) {
+        List<String> keywords = Arrays.asList(keyword.split("\\s+")); // 공백 기준으로 키워드 분리
+        return userDataFoodMapper.findByMultipleKeywords(keywords);
     }
+
 
     public List<ResponseUserDataFood> getUserDataFoodWithNickname(String udfName) {
         return userDataFoodMapper.findByUdfNameWithNickname(udfName);

--- a/dieat/src/main/java/com/samsung/dieat/user_data_food/query/service/UserDataFoodQueryService.java
+++ b/dieat/src/main/java/com/samsung/dieat/user_data_food/query/service/UserDataFoodQueryService.java
@@ -1,5 +1,8 @@
 package com.samsung.dieat.user_data_food.query.service;
 
+import com.samsung.dieat.user_data_food.query.dto.ResponseUdfName;
+import com.samsung.dieat.user_data_food.query.dto.ResponseUserDataFood;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import com.samsung.dieat.user_data_food.query.dao.UserDataFoodMapper;
@@ -14,4 +17,13 @@ public class UserDataFoodQueryService {
     public UserDataFoodDTO getUserDataFoodByUdfCode(int udfCode) {
         return userDataFoodMapper.findByUdfCode(udfCode);
     }
+
+    public List<ResponseUdfName> getUserDataFoodByLikeName(String likeName) {
+        return userDataFoodMapper.findByLikeName(likeName);
+    }
+
+    public List<ResponseUserDataFood> getUserDataFoodWithNickname(String udfName) {
+        return userDataFoodMapper.findByUdfNameWithNickname(udfName);
+    }
+
 }

--- a/dieat/src/main/resources/mapper/user_data_food/query/UserDataFoodMapper.xml
+++ b/dieat/src/main/resources/mapper/user_data_food/query/UserDataFoodMapper.xml
@@ -43,11 +43,14 @@
     <resultMap id="UdfName" type="com.samsung.dieat.user_data_food.query.dto.ResponseUdfName">
         <result property="udfName" column="udf_name"/>
     </resultMap>
-    <select id="findByLikeName" parameterType="String" resultMap="UdfName">
+    <select id="findByMultipleKeywords" parameterType="String" resultMap="UdfName">
         SELECT
                udf_name
           FROM samsung.tbl_user_data_food
-         WHERE REPLACE(udf_name, ' ', '') LIKE CONCAT('%', REPLACE(#{likeName}, ' ', ''), '%')
+          WHERE
+            <foreach item="word" collection="keywords" separator=" AND ">
+                REPLACE(REPLACE(REPLACE(udf_name, '(', ''), ')', ''), ' ', '') LIKE CONCAT('%', REPLACE(REPLACE(REPLACE(#{word}, '(', ''), ')', ''), ' ', ''), '%')
+            </foreach>
          GROUP BY udf_name
     </select>
 

--- a/dieat/src/main/resources/mapper/user_data_food/query/UserDataFoodMapper.xml
+++ b/dieat/src/main/resources/mapper/user_data_food/query/UserDataFoodMapper.xml
@@ -20,25 +20,69 @@
         <result property="udfCreatedDt" column="udf_created_dt"/>
         <result property="userCode" column="user_code"/>
     </resultMap>
-    <select id="findByUdfCode" parameterType="int"
-            resultMap="returnDTO">
+    <select id="findByUdfCode" parameterType="int" resultMap="returnDTO">
         SELECT
-            udf_code,
-            udf_name,
-            udf_sv_size,
-            udf_uom,
-            udf_sv_unit,
-            udf_calories,
-            udf_carbs,
-            udf_protein,
-            udf_fat,
-            udf_sugar,
-            udf_acc_cnt,
-            udf_inacc_cnt,
-            udf_created_dt,
-            user_code
+            udf_code
+             , udf_name
+             , udf_sv_size
+             , udf_uom
+             , udf_sv_unit
+             , udf_calories
+             , udf_carbs
+             , udf_protein
+             , udf_fat
+             , udf_sugar
+             , udf_acc_cnt
+             , udf_inacc_cnt
+             , udf_created_dt
+             , user_code
         FROM tbl_user_data_food
         WHERE udf_code = #{udfCode}
     </select>
 
+    <resultMap id="UdfName" type="com.samsung.dieat.user_data_food.query.dto.ResponseUdfName">
+        <result property="udfName" column="udf_name"/>
+    </resultMap>
+    <select id="findByLikeName" parameterType="String" resultMap="UdfName">
+        SELECT
+               udf_name
+          FROM samsung.tbl_user_data_food
+         WHERE udf_name LIKE CONCAT('%', #{likeName}, '%')
+         GROUP BY udf_name
+    </select>
+
+    <resultMap id="FoodWithNickname" type="com.samsung.dieat.user_data_food.query.dto.ResponseUserDataFood">
+        <result property="udfName" column="udf_name"/>
+        <result property="udfSvSize" column="udf_sv_size"/>
+        <result property="udfUom" column="udf_uom"/>
+        <result property="udfSvUnit" column="udf_sv_unit"/>
+        <result property="udfCalories" column="udf_calories"/>
+        <result property="udfCarbs" column="udf_carbs"/>
+        <result property="udfProtein" column="udf_protein"/>
+        <result property="udfFat" column="udf_fat"/>
+        <result property="udfSugar" column="udf_sugar"/>
+        <result property="udfAccCnt" column="udf_acc_cnt"/>
+        <result property="udfInaccCnt" column="udf_inacc_cnt"/>
+        <result property="udfCreatedDt" column="udf_created_dt"/>
+        <result property="userNickname" column="user_nickname"/>
+    </resultMap>
+    <select id="findByUdfNameWithNickname" parameterType="string" resultMap="FoodWithNickname">
+     SELECT
+            f.udf_name
+          , f.udf_sv_size
+          , f.udf_uom
+          , f.udf_sv_unit
+          , f.udf_calories
+          , f.udf_carbs
+          , f.udf_protein
+          , f.udf_fat
+          , f.udf_sugar
+          , f.udf_acc_cnt
+          , f.udf_inacc_cnt
+          , f.udf_created_dt
+          , u.user_nickname
+       FROM tbl_user_data_food f
+       JOIN tbl_user_info u ON f.user_code = u.user_code
+      WHERE f.udf_name = #{udfName}
+     </select>
 </mapper>

--- a/dieat/src/main/resources/mapper/user_data_food/query/UserDataFoodMapper.xml
+++ b/dieat/src/main/resources/mapper/user_data_food/query/UserDataFoodMapper.xml
@@ -47,7 +47,7 @@
         SELECT
                udf_name
           FROM samsung.tbl_user_data_food
-         WHERE udf_name LIKE CONCAT('%', #{likeName}, '%')
+         WHERE REPLACE(udf_name, ' ', '') LIKE CONCAT('%', REPLACE(#{likeName}, ' ', ''), '%')
          GROUP BY udf_name
     </select>
 


### PR DESCRIPTION
## 변경 사항 요약
- #39 
- 메뉴 이름으로 검색

## 상세 설명
- /like/메뉴이름 으로 요청이 들어오면 비슷한 결과들이 '한번씩' 나옴
  - 양파를 검색하면 양파, 양파링, 양파찜 등이 검색됨
  - 양파가 2개 등록되어있더라도 1개만 반환됨
  - 다른 정보는 검색되지 않고 이름만 검색됨
-  /name/메뉴이름 으로 요청이 들어오면 이름이 정확히 일치하는 결과들만 검색됨
  - 음식에 대한 상세 정보들이 모두 표시됨
  - 음식을 등록한 유저 코드 대신 유저의 닉네임이 반환됨

## 체크리스트
- [x] 코드 포맷 체크
- [x] 테스트 통과 확인
- [ ] 문서 업데이트 여부
